### PR TITLE
Secure Key is empty

### DIFF
--- a/v1.5.x - 1.6.x/mercadopago/controllers/front/custompayment.php
+++ b/v1.5.x - 1.6.x/mercadopago/controllers/front/custompayment.php
@@ -71,7 +71,10 @@ class MercadoPagoCustomPaymentModuleFrontController extends ModuleFrontControlle
 										$total,
 										$mercadopago->displayName,
 										null,
-										$extra_vars, $cart->id_currency);
+										$extra_vars,
+										$cart->id_currency,
+										false,
+										$cart->secure_key);
 
 			$order = new Order($mercadopago->currentOrder);
 			$order_payments = $order->getOrderPayments();

--- a/v1.5.x - 1.6.x/mercadopago/includes/mercadopago.php
+++ b/v1.5.x - 1.6.x/mercadopago/includes/mercadopago.php
@@ -30,6 +30,15 @@ class MP {
 
 	const VERSION = '3.0.5';
 
+	/*Info*/
+	const INFO = 1;
+	/*Warning*/
+	const WARNING = 2;
+	/*Error*/
+	const ERROR = 3;
+	/*Fatal Error*/
+	const FATAL_ERROR = 4;
+
 	private $client_id;
 	private $client_secret;
 	private $access_data;
@@ -235,9 +244,17 @@ class MPRestClient {
 			'status' => $api_http_code,
 			'response' => Tools::jsonDecode($api_result, true)
 		);
+		if (Configuration::get('MERCADOPAGO_LOG') == 'true') {
+			PrestaShopLogger::addLog('MercadoPago.exec :: data = '.Tools::jsonEncode($data), MP::INFO ,  0, null, null, true);
+			PrestaShopLogger::addLog('MercadoPago.exec :: response = '.$api_result, MP::INFO , $response['status'], null, null, true);
+		}
 
-		if ($response['status'] >= 400)
-			error_log('status: '.$response['status'].' error: '.$response['response']['message']);
+		if ($response['status'] == 0) {
+			$error = 'Can not call the API, status code 0.';
+   			throw new Exception($error);
+		} else if ($response['status'] > 202){
+			PrestaShopLogger::addLog("MercadoPago::exec = ".$response['response']['message'], MP::ERROR , $response['status']);
+		}
 
 		curl_close($connect);
 

--- a/v1.5.x - 1.6.x/mercadopago/views/templates/admin/settings.tpl
+++ b/v1.5.x - 1.6.x/mercadopago/views/templates/admin/settings.tpl
@@ -234,6 +234,18 @@
 					</select>
 				</div>
 			</fieldset>
+			<fieldset>
+				<legend>
+					<img src="../img/admin/contact.gif" />{l s='Settings - Active log' mod='mercadopago'}
+				</legend>
+				<label>{l s='Active: ' mod='mercadopago'}</label>
+				<div class="">
+					<select name="MERCADOPAGO_LOG" id="log_active">
+						<option value="true">{l s='Yes' mod='mercadopago'} </option>
+						<option value="false">{l s='No' mod='mercadopago'} </option>
+					</select>
+				</div>
+			</fieldset>			
 		{/if}
 		{if empty($country)}
 			<input type="submit" name="login" value="{l s='Login' mod='mercadopago'}" class="ch-btn ch-btn-big"/>
@@ -254,20 +266,30 @@
 	})
 	
 	window.onload = function() {
-		if (document.getElementById("category"))
+		if (document.getElementById("category")){
 			document.getElementById("category").value = "{$category|escape:'javascript'}";
+		}
 
-		if (document.getElementById("creditcard_active"))
+		if (document.getElementById("creditcard_active")){
 			document.getElementById("creditcard_active").value = "{$creditcard_active|escape:'javascript'}";
+		}
 
-		if (document.getElementById("standard_active"))
+		if (document.getElementById("standard_active")){
 			document.getElementById("standard_active").value = "{$standard_active|escape:'javascript'}";
+		}
 
-		if (document.getElementById("window_type"))
+
+		if (document.getElementById("log_active")){
+			document.getElementById("log_active").value = "{$log_active|escape:'javascript'}";
+		}
+
+		if (document.getElementById("window_type")){
 			document.getElementById("window_type").value = "{$window_type|escape:'javascript'}";
+		}
 
-		if (document.getElementById("auto_return"))
+		if (document.getElementById("auto_return")){
 			document.getElementById("auto_return").value = "{$auto_return|escape:'javascript'}";
+		}
 
 		{foreach from=$payment_methods_settings key=payment_method item=value}
 			document.getElementById("{$payment_method|escape:'javascript'}").checked = "{$value|escape:'javascript'}";

--- a/v1.5.x - 1.6.x/mercadopago/views/templates/front/error.tpl
+++ b/v1.5.x - 1.6.x/mercadopago/views/templates/front/error.tpl
@@ -87,9 +87,6 @@
 	{/if}
 	{if $valid_user}
 	</br>
-	{$message|escape:'htmlall'}
-	</br>
-	</br>
 		{l s='Card holder name: ' mod='mercadopago'}
 		{$card_holder_name|escape:'htmlall'}</br>
 		{l s='Credit card: ' mod='mercadopago'}
@@ -108,6 +105,13 @@
 		{/if}
 		{l s='Payment id (MercadoPago): ' mod='mercadopago'}
 		{$payment_id|escape:'htmlall'}</br>
+
+		<span>Henrique</span>
+		{if $message != null}
+			<span>{l s='Technical Error: ' mod='mercadopago'}</span>
+			{$message|escape:'htmlall'}</br>
+		{/if}	
+
 		{if $version == 6}
 			</div>
 		{/if}
@@ -127,6 +131,7 @@
 		{/if}
 	</div>
 </div>
+
 <script type="text/javascript">
 	$("#go-back").click(function () {
 		if ("{$one_step|escape:'htmlall'}" == 1)

--- a/v1.5.x - 1.6.x/mercadopago/views/templates/front/error_admin.tpl
+++ b/v1.5.x - 1.6.x/mercadopago/views/templates/front/error_admin.tpl
@@ -1,0 +1,54 @@
+{**
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    ricardobrito
+*  @copyright Copyright (c) MercadoPago [http://www.mercadopago.com]
+*  @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of MercadoPago
+*}
+<div class="mp-module">
+	{if $version == 5}
+		<div class="error">
+	{elseif $version == 6}
+		<div class="bootstrap">
+			<div class="alert alert-danger">
+	{/if}
+
+	{if $message_error != null}
+		<span class="error">{l s='Fatal Error' mod='mercadopago'}: </span>
+		{$message_error|escape:'htmlall'}</br>
+	{/if}	
+	{if $version == 6}
+		</div>
+	{/if}
+	</div>
+
+	<div>
+		<span>
+			<a href="#">{l s='Please visit https://groups.google.com/forum/#!category-topic/mercadopago-developers-brasil/payments-modules/t_aMeOyZSuY for more details about this error message.' mod='mercadopago'}</a>
+		</span>
+	</div>
+</div>
+
+<script type="text/javascript">
+	$("#go-back").click(function () {
+			window.history.go(-1);
+	});
+
+</script>

--- a/v1.5.x - 1.6.x/mercadopago/views/templates/hook/checkout.tpl
+++ b/v1.5.x - 1.6.x/mercadopago/views/templates/hook/checkout.tpl
@@ -353,38 +353,40 @@
 
     // Estabeleça a informação do meio de pagamento obtido
     function setPaymentMethodInfo(status, result){
-          //adiciona a imagem do meio de pagamento
-          var payment_method = result[0];
-          var amount = $("#amount").val();
-          var bin = getBin();
-          var json = {}
-          json.amount = amount;
-          json.bin = bin;
-		  Mercadopago.getInstallments(json, setInstallmentInfo);
+    	if(status != 404 && result != undefined){
+	          //adiciona a imagem do meio de pagamento
+	          var payment_method = result[0];
+	          var amount = $("#amount").val();
+	          var bin = getBin();
+	          var json = {}
+	          json.amount = amount;
+	          json.bin = bin;
+			  Mercadopago.getInstallments(json, setInstallmentInfo);
 
-		  if (country === "MLM" || country === "MLA") {
-			  // check if the issuer is necessary to pay
-				var issuerMandatory = false,
-				    additionalInfo = result[0].additional_info_needed;
+			  if (country === "MLM" || country === "MLA") {
+				  // check if the issuer is necessary to pay
+					var issuerMandatory = false,
+					    additionalInfo = result[0].additional_info_needed;
 
-				for (var i = 0; i < additionalInfo.length; i++) {
-				    if (additionalInfo[i] == "issuer_id") {
-				        issuerMandatory = true;
-				    }
+					for (var i = 0; i < additionalInfo.length; i++) {
+					    if (additionalInfo[i] == "issuer_id") {
+					        issuerMandatory = true;
+					    }
+					}
+
+					if (issuerMandatory) {
+					    Mercadopago.getIssuers(result[0].id, showCardIssuers);
+					    $("#id-issuers-options").bind("change",function(){ setInstallmentsByIssuerId(status, result) });
+					} else {
+					    document.querySelector("#id-issuers-options").options.length = 0;
+					    document.querySelector("#id-issuers-options").style.display = 'none';
+					    document.querySelector(".issuers-options").style.display = 'none';
+					}
 				}
 
-				if (issuerMandatory) {
-				    Mercadopago.getIssuers(result[0].id, showCardIssuers);
-				    $("#id-issuers-options").bind("change",function(){ setInstallmentsByIssuerId(status, result) });
-				} else {
-				    document.querySelector("#id-issuers-options").options.length = 0;
-				    document.querySelector("#id-issuers-options").style.display = 'none';
-				    document.querySelector(".issuers-options").style.display = 'none';
-				}
-			}
-
-		  $("#id-card-number").css("background", "url(" + payment_method.secure_thumbnail + ") 98% 50% no-repeat");
-		  $("#payment_method_id").val($("input[name=card-types]:checked").val() ? $("input[name=card-types]:checked").val() + payment_method.id : payment_method.id);
+			  $("#id-card-number").css("background", "url(" + payment_method.secure_thumbnail + ") 98% 50% no-repeat");
+			  $("#payment_method_id").val($("input[name=card-types]:checked").val() ? $("input[name=card-types]:checked").val() + payment_method.id : payment_method.id);
+		}
     };
 
     function setInstallmentsByIssuerId(status, response) {
@@ -404,12 +406,16 @@
 
     //Mostre as parcelas disponíveis no div 'installmentsOption'
     function setInstallmentInfo(status, installments){
-        var html_options = "";
-        var installments = installments[0].payer_costs;
-        $.each(installments, function(key, value) {
-            html_options += "<option value='"+ value.installments + "'>"+ value.recommended_message + "</option>";
-        });
-        $("#id-installments").html(html_options);
+    	if (status != 404) {
+	        var html_options = "";
+	        var installments = installments[0].payer_costs;
+	        $.each(installments, function(key, value) {
+	            html_options += "<option value='"+ value.installments + "'>"+ value.recommended_message + "</option>";
+	        });
+	        $("#id-installments").html(html_options);
+    	} else {
+    		console.info(installments);
+    	}
 	};
 
 	// function showIssuers(status, issuers){


### PR DESCRIPTION
Some user was complaining about the message "Warning: the secure key is empty, check your payment account before validation"

Was necessary to send the parameter $cart->secure_key for the function PaymentModuleCore.validateOrder